### PR TITLE
check token before checking permissions

### DIFF
--- a/EventListener/EnforcePasswordChangeListener.php
+++ b/EventListener/EnforcePasswordChangeListener.php
@@ -17,6 +17,7 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 class EnforcePasswordChangeListener implements EventSubscriberInterface
@@ -95,11 +96,16 @@ class EnforcePasswordChangeListener implements EventSubscriberInterface
             return;
         }
 
+        $token = $this->tokenStorage->getToken();
+        if (!$token instanceof TokenInterface) {
+            return;
+        }
+
         if (!$this->authorizationChecker->isGranted('IS_AUTHENTICATED_FULLY')) {
             return;
         }
 
-        $user = $this->tokenStorage->getToken()->getUser();
+        $user = $token->getUser();
         if (!($user instanceof EnforceablePasswordChangeInterface) ||
             !$user->isForcedToChangePassword()) {
             return;

--- a/EventListener/EnforcePasswordChangeListener.php
+++ b/EventListener/EnforcePasswordChangeListener.php
@@ -97,7 +97,7 @@ class EnforcePasswordChangeListener implements EventSubscriberInterface
         }
 
         $token = $this->tokenStorage->getToken();
-        if (!$token instanceof TokenInterface) {
+        if (!$token) {
             return;
         }
 


### PR DESCRIPTION
if the user enters a "`404`" page that's behind firewall and also the user is authorized, calling `->isGranted(...)` will cause:

> AuthenticationCredentialsNotFoundException
> The token storage contains no authentication token. One possible reason may be that there is no firewall configured for this URL.

404 is then changed with 500 error. This is due that url's are resolved before firewall starts
