### PR TITLE
Simplify route overwriting

### DIFF
--- a/Behat/Context/Page/Activation.php
+++ b/Behat/Context/Page/Activation.php
@@ -7,7 +7,7 @@ use SensioLabs\Behat\PageObjectExtension\PageObject\Page;
 
 class Activation extends Page
 {
-    protected $path = '/admin/activation/{activationToken}';
+    protected $path = '/admin/activation/activate/{activationToken}';
 
     public function verifyPage()
     {

--- a/Behat/Context/Page/PasswordResetChangePassword.php
+++ b/Behat/Context/Page/PasswordResetChangePassword.php
@@ -7,7 +7,7 @@ use SensioLabs\Behat\PageObjectExtension\PageObject\Page;
 
 class PasswordResetChangePassword extends Page
 {
-    protected $path = '/admin/password-reset/{confirmationToken}';
+    protected $path = '/admin/password-reset/change-password/{confirmationToken}';
 
     public function verifyPage()
     {

--- a/Resources/config/routing/admin_activation.yml
+++ b/Resources/config/routing/admin_activation.yml
@@ -1,5 +1,5 @@
 fsi_admin_activation:
-    path: /activation/{token}
+    path: /activation/activate/{token}
     defaults:
         _controller: admin_security.controller.activation:activateAction
 

--- a/Resources/config/routing/admin_password_reset.yml
+++ b/Resources/config/routing/admin_password_reset.yml
@@ -4,6 +4,6 @@ fsi_admin_security_password_reset_request:
         _controller: admin_security.controller.password_reset.request:requestAction
 
 fsi_admin_security_password_reset_change_password:
-    path: /password-reset/{token}
+    path: /password-reset/change-password/{token}
     defaults:
         _controller: admin_security.controller.password_reset.change_password:changePasswordAction


### PR DESCRIPTION
routes in application are matched in order they are defined. If you want to override for example `fsi_admin_security_password_reset_request` route in application you also have to redefine `fsi_admin_security_password_reset_change_password` because path:

```
/password-reset/request
```

will be matched to:

```
/password-reset/{token}
```

when defined in reverse order. Same with "activate"
