### PR TITLE
Removed unneccessary target-dir option in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,6 @@
             "FSi\\Bundle\\AdminSecurityBundle\\": ""
         }
     },
-    "target-dir" : "FSi/Bundle/AdminSecurityBundle",
     "extra": {
         "branch-alias": {
             "dev-master": "1.1-dev"


### PR DESCRIPTION
Apparently this option breaks package updates on Packagist and needs to be removed. It is a deprecated feature used only when having PSR-0 loading method.