### PR TITLE
Compatibility with latest FOSUserBundle

### DIFF
--- a/FSiAdminSecurityBundle.php
+++ b/FSiAdminSecurityBundle.php
@@ -34,7 +34,7 @@ class FSiAdminSecurityBundle extends Bundle
 
         $container->addCompilerPass(DoctrineOrmMappingsPass::createXmlMappingDriver($mappings));
 
-        if ($container->hasExtension('fos_user')) {
+        if ($container->hasExtension('fos_user') && class_exists('FOS\UserBundle\Entity\User')) {
             $mappings = array(
                 $doctrineConfigDir . '/FOS' => 'FSi\Bundle\AdminSecurityBundle\Security\FOS',
             );


### PR DESCRIPTION
https://github.com/FriendsOfSymfony/FOSUserBundle/blob/master/Changelog.md

```
2.0.0-alpha2 (2015-09-15)
[BC break] The deprecated entity classes have been removed.
```
