### PR TITLE
Use FlashMessage in SecurityController

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -40,3 +40,9 @@ has been added. Just add a link pointing to the `fsi_admin_security_password_res
 path somewhere in a place reachable by anonymous users and you are good to go.
 Again, please refer to the [configuration](Resources/doc/configuration.md) for
 more information on customizing this action.
+
+# Login form errors displayed by flash messages
+
+Previously these were displayed as form errors, that used the `FSiAdminSecurity`
+translation domain. Now they are displayed through flash messages using the default
+`security` domain.

--- a/Controller/SecurityController.php
+++ b/Controller/SecurityController.php
@@ -9,6 +9,7 @@
 
 namespace FSi\Bundle\AdminSecurityBundle\Controller;
 
+use FSi\Bundle\AdminBundle\Message\FlashMessages;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 
@@ -25,27 +26,47 @@ class SecurityController
     private $authenticationUtils;
 
     /**
+     * @var FlashMessages
+     */
+    private $flashMessages;
+
+    /**
      * @var string
      */
     private $loginActionTemplate;
 
     /**
      * @param EngineInterface $templating
-     * @param \Symfony\Component\Security\Http\Authentication\AuthenticationUtils $authenticationUtils
+     * @param AuthenticationUtils $authenticationUtils
+     * @param FlashMessages $flashMessages
      * @param string $loginActionTemplate
      */
-    function __construct(EngineInterface $templating, AuthenticationUtils $authenticationUtils, $loginActionTemplate)
-    {
+    public function __construct(
+        EngineInterface $templating,
+        AuthenticationUtils $authenticationUtils,
+        FlashMessages $flashMessages,
+        $loginActionTemplate
+    ) {
         $this->templating = $templating;
         $this->authenticationUtils = $authenticationUtils;
+        $this->flashMessages = $flashMessages;
         $this->loginActionTemplate = $loginActionTemplate;
     }
 
     public function loginAction()
     {
-        return $this->templating->renderResponse($this->loginActionTemplate, [
-            'error' => $this->authenticationUtils->getLastAuthenticationError(),
-            'last_username' => $this->authenticationUtils->getLastUsername()
-        ]);
+        $error = $this->authenticationUtils->getLastAuthenticationError();
+        if ($error) {
+            $this->flashMessages->error(
+                $error->getMessageKey(),
+                'security',
+                $error->getMessageData()
+            );
+        }
+
+        return $this->templating->renderResponse(
+            $this->loginActionTemplate,
+            ['last_username' => $this->authenticationUtils->getLastUsername()]
+        );
     }
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -45,6 +45,7 @@
         <service id="admin_security.controller.security" class="%admin_security.controller.security.class%">
             <argument type="service" id="templating" />
             <argument type="service" id="security.authentication_utils" />
+            <argument type="service" id="admin.messages.flash" />
             <argument type="string">%admin_security.templates.login%</argument>
         </service>
 

--- a/Resources/translations/FSiAdminSecurity.en.yml
+++ b/Resources/translations/FSiAdminSecurity.en.yml
@@ -1,6 +1,3 @@
-# Security
-"Bad credentials.": Invalid username or password
-
 admin:
   login:
     email:

--- a/Resources/translations/FSiAdminSecurity.pl.yml
+++ b/Resources/translations/FSiAdminSecurity.pl.yml
@@ -1,6 +1,3 @@
-# Security
-"Bad credentials.": Nieprawidłowa nazwa użytkownika lub hasło
-
 admin:
   login:
     email:

--- a/Resources/views/Security/login.html.twig
+++ b/Resources/views/Security/login.html.twig
@@ -4,9 +4,6 @@
     {{ parent() }}
 
     <form class="form-signin" role="form" action="{{ path("fsi_admin_security_user_check") }}" method="post">
-        {% if error %}
-        <div class="alert alert-danger">{{ error.message|trans({}, 'FSiAdminSecurity') }}</div>
-        {% endif %}
         <input type="text" name="_username" class="form-control" placeholder="{{ 'admin.login.email.placeholder'|trans({}, 'FSiAdminSecurity') }}" value="{{ last_username }}" required autofocus>
         <input type="password" name="_password" class="form-control" placeholder="{{ 'admin.login.password.placeholder'|trans({}, 'FSiAdminSecurity') }}" required>
         <input type="hidden" name="_csrf_token" value="{{ csrf_token('admin_authenticate') }}" />

--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -65,3 +65,8 @@ class SomeAdminElement extends CRUDElement implemends SecuredElementInterface
 
 }
 ```
+
+## Change translation domain for custom login form errors (not often)
+
+Since the login form now uses the `security` domain instead of `FSiAdminSecurity`,
+you will have to move any custom login form error messages there.

--- a/features/admin/secure_admin_panel.feature
+++ b/features/admin/secure_admin_panel.feature
@@ -26,7 +26,10 @@ Feature: Secure admin panel
     Given I am on the "Login" page
     When I fill form with invalid admin login and password
     And I press "Login" button
-    Then I should see login form error message "Invalid username or password"
+    And I should see message:
+    """
+    Invalid credentials.
+    """
 
   Scenario: Logout from admin panel
     Given I'm logged in as admin


### PR DESCRIPTION
Resolves #60

TODO:
- [x] Documentation
- [x] Remove `"Bad credentials."` from `FSiAdminSecurity` translation domain.