### PR TITLE
Display same message for all cases in reset password request

### DIFF
--- a/Behat/Context/AdminContext.php
+++ b/Behat/Context/AdminContext.php
@@ -9,6 +9,7 @@
 
 namespace FSi\Bundle\AdminSecurityBundle\Behat\Context;
 
+use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Mink;
 use Behat\MinkExtension\Context\MinkAwareContext;
@@ -112,11 +113,11 @@ class AdminContext extends PageObjectContext implements KernelAwareContext, Mink
     }
 
     /**
-     * @Given /^I should see message "([^"]*)"$/
+     * @Given /^I should see message:$/
      */
-    public function iShouldSeeMessage($message)
+    public function iShouldSeeMessage(PyStringNode $message)
     {
-        expect($this->getElement('FlashMessage')->getText())->toBe($message);
+        expect($this->getElement('FlashMessage')->getText())->toBe($message->getRaw());
     }
 
     /**

--- a/Behat/Context/PasswordResetContext.php
+++ b/Behat/Context/PasswordResetContext.php
@@ -137,16 +137,6 @@ class PasswordResetContext extends PageObjectContext implements KernelAwareConte
     }
 
     /**
-     * @Then /^I should see password reset request form message "([^"]*)"$/
-     */
-    public function iShouldSeePasswordResetRequestFormMessage($message)
-    {
-        /** @var PasswordResetRequest $page */
-        $page = $this->getPage('Password Reset Request');
-        expect($page->getMessage())->toBe($message);
-    }
-
-    /**
      * @When /^i try open password change page with token "([^"]*)"$/
      */
     public function iTryOpenPasswordChangePageWithToken($confirmationToken)

--- a/Controller/Activation/ActivationController.php
+++ b/Controller/Activation/ActivationController.php
@@ -147,9 +147,8 @@ class ActivationController
             $user,
             ['validation_groups' => $this->changePasswordFormValidationGroups]
         );
-        $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->handleRequest($request)->isSubmitted() && $form->isValid()) {
             $this->eventDispatcher->dispatch(
                 AdminSecurityEvents::ACTIVATION,
                 new ActivationEvent($user)

--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -114,9 +114,8 @@ class AdminController
             $user,
             ['validation_groups' => $this->changePasswordFormValidationGroups]
         );
-        $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->handleRequest($request)->isSubmitted() && $form->isValid()) {
 
             $this->eventDispatcher->dispatch(
                 AdminSecurityEvents::CHANGE_PASSWORD,

--- a/Controller/PasswordReset/ChangePasswordController.php
+++ b/Controller/PasswordReset/ChangePasswordController.php
@@ -124,9 +124,8 @@ class ChangePasswordController
             $user,
             ['validation_groups' => $this->formValidationGroups]
         );
-        $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->handleRequest($request)->isSubmitted() && $form->isValid()) {
             $user->removePasswordResetToken();
 
             $this->eventDispatcher->dispatch(

--- a/Controller/PasswordReset/ResetRequestController.php
+++ b/Controller/PasswordReset/ResetRequestController.php
@@ -95,18 +95,19 @@ class ResetRequestController
         $form = $this->formFactory->create($this->formType);
 
         if ($form->handleRequest($request)->isSubmitted() && $form->isValid()) {
-
             $user = $this->getUser($form);
+            $redirectResponse = $this->addFlashAndRedirect('info', 'admin.password_reset.request.mail_sent_if_correct');
+
             if (!($user instanceof ResettablePasswordInterface)) {
-                return $this->addFlashAndRedirect('info', 'admin.password_reset.request.mail_sent_if_correct');
+                return $redirectResponse;
             }
 
             if ($this->hasNonExpiredPasswordResetToken($user)) {
-                return $this->addFlashAndRedirect('warning', 'admin.password_reset.request.already_requested');
+                return $redirectResponse;
             }
 
             if (($user instanceof AdvancedUserInterface) && !$user->isAccountNonLocked()) {
-                return $this->addFlashAndRedirect('warning', 'admin.password_reset.request.account_locked');
+                return $redirectResponse;
             }
 
             $this->eventDispatcher->dispatch(
@@ -114,7 +115,7 @@ class ResetRequestController
                 new ResetPasswordRequestEvent($user)
             );
 
-            return $this->addFlashAndRedirect('info', 'admin.password_reset.request.mail_sent_if_correct');
+            return $redirectResponse;
         }
 
         return $this->templating->renderResponse(

--- a/Controller/PasswordReset/ResetRequestController.php
+++ b/Controller/PasswordReset/ResetRequestController.php
@@ -93,9 +93,8 @@ class ResetRequestController
     public function requestAction(Request $request)
     {
         $form = $this->formFactory->create($this->formType);
-        $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->handleRequest($request)->isSubmitted() && $form->isValid()) {
 
             $user = $this->getUser($form);
             if (!($user instanceof ResettablePasswordInterface)) {

--- a/Resources/translations/FSiAdminSecurity.en.yml
+++ b/Resources/translations/FSiAdminSecurity.en.yml
@@ -26,13 +26,13 @@ admin:
         email: Email
         button:
           send: Send me instructions
-      mail_sent_if_correct: If the provided address was correct, you should receive instructions on resetting your password.
+      mail_sent_if_correct: >
+        If Your account is active and the provided address is correct, You should
+        receive instructions on resetting Your password.
       mail_subject: Reset Password
       mail:
         info: "To reset your password - please visit:"
         requested_by: "%ip% - %user_agent%"
-      already_requested: You already requested password reset instructions. Check your email.
-      account_locked: User account is locked.
     change_password:
       form:
         password: New password

--- a/Resources/translations/FSiAdminSecurity.pl.yml
+++ b/Resources/translations/FSiAdminSecurity.pl.yml
@@ -26,13 +26,13 @@ admin:
         email: Email
         button:
           send: Wyślij mi instrukcje
-      mail_sent_if_correct: Jeśli podany email był prawidłowy, to powinieneś otrzymać na niego instrukcję zmiany hasła.
+      mail_sent_if_correct: >
+        Jeśli Twoje konto jest aktywne i podany email jest prawidłowy, to powinieneś
+        otrzymać na niego instrukcję zmiany hasła.
       mail_subject: Zmiana hasła
       mail:
         info: "Aby ustawić nowe hasło proszę otworzyć link:"
         requested_by: "%ip% - %user_agent%"
-      already_requested: Instrukcja zmiany hasła została już wysłana. Sprawdź pocztę.
-      account_locked: Twoje konto jest zablokowane.
     change_password:
       form:
         password: Nowe hasło

--- a/features/activation/activation.feature
+++ b/features/activation/activation.feature
@@ -17,5 +17,8 @@ Feature: Activation of disabled user
   Scenario: Activate user
     When i open activation page with token received by user "user@example.com" in the email
     Then I should be redirected to "Login" page
-    And I should see message "Your account has been successfully activated"
+    And I should see message:
+    """
+    Your account has been successfully activated
+    """
     And user "user@example.com" should be enabled

--- a/features/activation/activation_password_change.feature
+++ b/features/activation/activation_password_change.feature
@@ -25,12 +25,18 @@ Feature: Activation of disabled user with enforced password change
 
   Scenario: Submit activation form with valid data
     Given i open activation page with token received by user "user@example.com" in the email
-    Then I should see message "Please setup a new password to activate your account"
+    Then I should see message:
+    """
+    Please setup a new password to activate your account
+    """
     When i fill in new password with confirmation
     And I press "Activate account" button
     And I should be redirected to "Login" page
     Then user "user@example.com" should have changed password
-    And I should see message "Your password has been successfully changed and your account has been activated"
+    And I should see message:
+    """
+    Your password has been successfully changed and your account has been activated
+    """
     And user "user@example.com" should be enabled
 
   Scenario: Submit activation form with invalid data

--- a/features/admin/admin_change_password.feature
+++ b/features/admin/admin_change_password.feature
@@ -29,7 +29,10 @@ Feature: Admin change password
     And I press "Save"
     Then user password should be changed
     And I should be redirected to "Login" page
-    And I should see message "Your password has been successfully changed"
+    And I should see message:
+    """
+    Your password has been successfully changed
+    """
 
   Scenario: Submit change form with invalid current password
     Given I am on the "Admin change password" page

--- a/features/admin/enforce_password_change.feature
+++ b/features/admin/enforce_password_change.feature
@@ -17,4 +17,7 @@ Feature: Admin change password
     And I change my password
     Then user "redactor" should have changed password
     And I should be redirected to "Login" page
-    And I should see message "Your password has been successfully changed"
+    And I should see message:
+    """
+    Your password has been successfully changed
+    """

--- a/features/password_reset/password_reset_change_password.feature
+++ b/features/password_reset/password_reset_change_password.feature
@@ -23,7 +23,10 @@ Feature:
     And I press "Change password" button
     And I should be redirected to "Login" page
     Then user "admin@fsi.pl" should have changed password
-    And I should see message "Your password has been successfully changed"
+    And I should see message:
+    """
+    Your password has been successfully changed
+    """
 
   Scenario: Submit change password form with invalid data
     When i open password change page with token "EwAq42G68-dg5Jl-HGr3Z7wII4cYh3sUvSpcdLhVxRQ"

--- a/features/password_reset/password_reset_request.feature
+++ b/features/password_reset/password_reset_request.feature
@@ -12,7 +12,10 @@ Feature: Request URI for password change form
     Given I am on the "Password Reset Request" page
     When I fill form with non-existent email address
     And I press "Send me instructions" button
-    Then I should see password reset request form message "If the provided address was correct, you should receive instructions on resetting your password."
+    Then I should see message:
+    """
+    If Your account is active and the provided address is correct, You should receive instructions on resetting Your password.
+    """
     And no emails were sent
 
   @email
@@ -20,7 +23,10 @@ Feature: Request URI for password change form
     Given I am on the "Password Reset Request" page
     When I fill form with correct email address
     And I press "Send me instructions" button
-    Then I should see password reset request form message "If the provided address was correct, you should receive instructions on resetting your password."
+    Then I should see message:
+    """
+    If Your account is active and the provided address is correct, You should receive instructions on resetting Your password.
+    """
     And I should receive email:
       | subject  | Reset Password           |
       | from     | from-admin@fsi.pl        |
@@ -32,6 +38,9 @@ Feature: Request URI for password change form
     And I am on the "Password Reset Request" page
     When I fill form with correct email address
     And I press "Send me instructions" button
-    Then I should see message "You already requested password reset instructions. Check your email."
+    Then I should see message:
+    """
+    If Your account is active and the provided address is correct, You should receive instructions on resetting Your password.
+    """
     And I should be on the "Login" page
     And user "admin@fsi.pl" should still have confirmation token "EwAq42G68-dg5Jl-HGr3Z7wII4cYh3sUvSpcdLhVxRQ"

--- a/spec/FSi/Bundle/AdminSecurityBundle/Controller/Activation/ActivationControllerSpec.php
+++ b/spec/FSi/Bundle/AdminSecurityBundle/Controller/Activation/ActivationControllerSpec.php
@@ -31,7 +31,8 @@ class ActivationControllerSpec extends ObjectBehavior
         FormView $formView,
         EventDispatcherInterface $eventDispatcher,
         UserInterface $user,
-        FlashMessages $flashMessages
+        FlashMessages $flashMessages,
+        Request $request
     ) {
         $formFactory->create(
             'form_type',
@@ -39,6 +40,8 @@ class ActivationControllerSpec extends ObjectBehavior
             ['validation_groups' => ['validation_group']]
         )->willReturn($form);
         $form->createView()->willReturn($formView);
+        $form->handleRequest($request)->willReturn($form);
+        $form->isSubmitted()->willReturn(true);
 
         $this->beConstructedWith(
             $templating,

--- a/spec/FSi/Bundle/AdminSecurityBundle/Controller/AdminControllerSpec.php
+++ b/spec/FSi/Bundle/AdminSecurityBundle/Controller/AdminControllerSpec.php
@@ -26,8 +26,12 @@ class AdminControllerSpec extends ObjectBehavior
         TokenStorageInterface $tokenStorage,
         RouterInterface $router,
         EventDispatcherInterface $eventDispatcher,
-        FlashMessages $flashMessages
+        FlashMessages $flashMessages,
+        FormInterface $form,
+        Request $request
     ) {
+        $form->handleRequest($request)->willReturn($form);
+        $form->isSubmitted()->willReturn(true);
         $this->beConstructedWith(
             $templating,
             $formFactory,

--- a/spec/FSi/Bundle/AdminSecurityBundle/Controller/PasswordReset/ChangePasswordControllerSpec.php
+++ b/spec/FSi/Bundle/AdminSecurityBundle/Controller/PasswordReset/ChangePasswordControllerSpec.php
@@ -55,6 +55,8 @@ class ChangePasswordControllerSpec extends ObjectBehavior
         EventDispatcherInterface $eventDispatcher,
         FlashMessages $flashMessages
     ) {
+        $form->handleRequest($request)->willReturn($form);
+        $form->isSubmitted()->willReturn(true);
         $userRepository->findUserByPasswordResetToken('token12345')->willReturn($user);
         $user->getPasswordResetToken()->willReturn($token);
         $token->isNonExpired()->willReturn(true);

--- a/spec/FSi/Bundle/AdminSecurityBundle/Controller/PasswordReset/ResetRequestControllerSpec.php
+++ b/spec/FSi/Bundle/AdminSecurityBundle/Controller/PasswordReset/ResetRequestControllerSpec.php
@@ -58,7 +58,8 @@ class ResetRequestControllerSpec extends ObjectBehavior
         $flashMessages
     ) {
         $formFactory->create('form_type')->willReturn($form);
-        $form->handleRequest($request)->shouldBeCalled();
+        $form->handleRequest($request)->willReturn($form);
+        $form->isSubmitted()->willReturn(true);
         $form->isValid()->willReturn(true);
 
         $form->get('email')->willReturn($form2);


### PR DESCRIPTION
The form submission was done due to deprecation in Symfony [3.2](https://github.com/symfony/symfony/blob/master/CHANGELOG-3.2.md):
```
feature #17644 Deprecate using Form::isValid() with an unsubmitted form (Ener-Getick)
```

Resolves #61 and #79